### PR TITLE
nextのlinkでasを使うように修正

### DIFF
--- a/src/components/organisms/Post/index.tsx
+++ b/src/components/organisms/Post/index.tsx
@@ -12,7 +12,7 @@ interface P {
 
 const Post: React.FC<P> = ({ meta }) => {
   return (
-    <Link href={`/posts/${meta.id}`}>
+    <Link href="/posts/[id]" as={`/posts/${meta.id}`}>
       <a className={styles.link} aria-label={meta.title}>
         <Card tag="article" className={styles.component}>
           <h2 className={styles.title}>{meta.title}</h2>


### PR DESCRIPTION
`next/link` では、ちゃんと chunk を取得できるように `as` で指定してあげないと production build をした時にエラーになる。
エラーになった場合、 chunk が見つからないので、 SSR で移動しようとする。そのためページ遷移が遅く感じる。

https://nextjs.org/docs/routing/introduction